### PR TITLE
Fix: Normalize usernames for case-insensitive lookups

### DIFF
--- a/engine/src/main/kotlin/world/gregs/voidps/engine/data/sql/DatabaseStorage.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/data/sql/DatabaseStorage.kt
@@ -48,9 +48,9 @@ class DatabaseStorage : AccountStorage {
             .groupBy(AccountsTable.id)
             .associate { row ->
                 val variables: Map<String, Any> = row[names].mapIndexed { index, s -> s to if (s == "coin_share_setting") row[booleans][index] else row[strings][index] }.toMap()
-                val playerName = row[AccountsTable.name]
-                val displayName = variables["display_name"] as? String ?: playerName
-                displayName.lowercase() to Clan(
+                val playerName = row[AccountsTable.name].lowercase()
+                val displayName = variables["display_name"] as? String ?: row[AccountsTable.name]
+                playerName to Clan(
                     owner = playerName,
                     ownerDisplayName = displayName,
                     name = variables["clan_name"] as? String ?: "",

--- a/engine/src/main/kotlin/world/gregs/voidps/engine/data/sql/DatabaseStorage.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/data/sql/DatabaseStorage.kt
@@ -125,7 +125,7 @@ class DatabaseStorage : AccountStorage {
         InventoriesTable.deleteWhere { playerId inList playerIds.values }
         val invData = accounts.flatMap { save -> save.inventories.toList().map { Triple(save.name, it.first, it.second) } }
         InventoriesTable.batchUpsert(invData, InventoriesTable.playerId, InventoriesTable.inventoryName) { (id, inventory, items) ->
-            this[InventoriesTable.playerId] = playerIds.getValue(id)
+            this[InventoriesTable.playerId] = playerIds.getValue(id.lowercase())
             this[InventoriesTable.inventoryName] = inventory
             this[InventoriesTable.items] = items.map { it.id }
             this[InventoriesTable.amounts] = items.map { it.value }
@@ -137,7 +137,7 @@ class DatabaseStorage : AccountStorage {
         VariablesTable.deleteWhere { playerId inList playerIds.values }
         val varData = accounts.flatMap { save -> save.variables.toList().map { Triple(save.name, it.first, it.second) } }
         VariablesTable.batchUpsert(varData, VariablesTable.playerId, VariablesTable.name) { (id, name, value) ->
-            this[VariablesTable.playerId] = playerIds.getValue(id)
+            this[VariablesTable.playerId] = playerIds.getValue(id.lowercase())
             this[VariablesTable.name] = name
             when (value) {
                 is String -> {
@@ -176,7 +176,7 @@ class DatabaseStorage : AccountStorage {
 
     private fun saveLevels(accounts: List<PlayerSave>, playerIds: Map<String, Int>) {
         LevelsTable.batchUpsert(accounts, LevelsTable.playerId) { playerSave ->
-            this[LevelsTable.playerId] = playerIds.getValue(playerSave.name)
+            this[LevelsTable.playerId] = playerIds.getValue(playerSave.name.lowercase())
             val levels = playerSave.levels
             this[LevelsTable.attack] = levels[0]
             this[LevelsTable.defence] = levels[1]
@@ -208,7 +208,7 @@ class DatabaseStorage : AccountStorage {
 
     private fun saveExperience(accounts: List<PlayerSave>, playerIds: Map<String, Int>) {
         ExperienceTable.batchUpsert(accounts, ExperienceTable.playerId) { playerSave ->
-            this[ExperienceTable.playerId] = playerIds.getValue(playerSave.name)
+            this[ExperienceTable.playerId] = playerIds.getValue(playerSave.name.lowercase())
             val experience = playerSave.experience
             this[ExperienceTable.attack] = experience[0]
             this[ExperienceTable.defence] = experience[1]

--- a/engine/src/main/kotlin/world/gregs/voidps/engine/data/sql/DatabaseStorage.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/data/sql/DatabaseStorage.kt
@@ -48,10 +48,10 @@ class DatabaseStorage : AccountStorage {
             .groupBy(AccountsTable.id)
             .associate { row ->
                 val variables: Map<String, Any> = row[names].mapIndexed { index, s -> s to if (s == "coin_share_setting") row[booleans][index] else row[strings][index] }.toMap()
-                val playerName = row[AccountsTable.name].lowercase()
-                val displayName = variables["display_name"] as? String ?: row[AccountsTable.name]
-                playerName to Clan(
-                    owner = playerName,
+                val accountName = row[AccountsTable.name]
+                val displayName = variables["display_name"] as? String ?: accountName
+                accountName.lowercase() to Clan(
+                    owner = accountName,
                     ownerDisplayName = displayName,
                     name = variables["clan_name"] as? String ?: "",
                     friends = row[AccountsTable.friends].zip(row[AccountsTable.ranks]) { friend, rank -> friend to ClanRank.valueOf(rank) }.toMap(),

--- a/game/src/main/kotlin/content/social/clan/ClanChat.kts
+++ b/game/src/main/kotlin/content/social/clan/ClanChat.kts
@@ -35,13 +35,10 @@ playerSpawn { player ->
         val account = accountDefinitions.getByAccount(current)
         joinClan(player, account?.displayName ?: "")
     }
-
-    val clan = accounts.clan(player.name)
-    if (clan != null && clan.owner.equals(player.accountName, ignoreCase = true)) {
-        player.ownClan = clan
-        clan.friends = player.friends
-        clan.ignores = player.ignores
-    }
+    val ownClan = accounts.clan(player.name.lowercase()) ?: return@playerSpawn
+    player.ownClan = ownClan
+    ownClan.friends = player.friends
+    ownClan.ignores = player.ignores
 }
 
 playerDespawn { player ->

--- a/game/src/main/kotlin/content/social/clan/ClanChat.kts
+++ b/game/src/main/kotlin/content/social/clan/ClanChat.kts
@@ -35,10 +35,13 @@ playerSpawn { player ->
         val account = accountDefinitions.getByAccount(current)
         joinClan(player, account?.displayName ?: "")
     }
-    val ownClan = accounts.clan(player.name) ?: return@playerSpawn
-    player.ownClan = ownClan
-    ownClan.friends = player.friends
-    ownClan.ignores = player.ignores
+
+    val clan = accounts.clan(player.name)
+    if (clan != null && clan.owner.equals(player.accountName, ignoreCase = true)) {
+        player.ownClan = clan
+        clan.friends = player.friends
+        clan.ignores = player.ignores
+    }
 }
 
 playerDespawn { player ->


### PR DESCRIPTION
This PR addresses issues with username casing inconsistencies between the application and PostgreSQL, particularly on Linux filesystems.

Changes:
- Lowercase keys in playerIds map.
- Apply `.lowercase()` during all map lookups in saveExperience, saveLevels, saveVariables, and saveInventories.
- Ensures compatibility with case-sensitive environments.

No changes were made to how names are stored in the database, preserving original casing.